### PR TITLE
Set permissions on ci.yml workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ env:
 jobs:
   sanity-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Version sanity checks
@@ -84,7 +86,10 @@ jobs:
     needs: sanity-checks
     name: "${{ matrix.platform.target }} / ${{ matrix.toolchain }}"
     runs-on: ${{ matrix.platform.os }}
-
+    # TODO: Split into separate jobs for tests and releases, with only the release job
+    # needing write permissions. Will require sharing artifacts between jobs.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes:

* https://github.com/kugland/neocities-deploy/security/code-scanning/2
* https://github.com/kugland/neocities-deploy/security/code-scanning/7

But this is only slightly more secure. The correct approach is the one delineated in the comment added to `.github/workflows/ci.yml`:

https://github.com/kugland/neocities-deploy/blob/235a59a503c63e766958d0d6b2ff93243999a454/.github/workflows/ci.yml#L85-L92

Possible solution for passing artifacts from one job to the next:

> You can use the Github Actions [upload-artifact](https://github.com/actions/upload-artifact) and [download-artifact](https://github.com/actions/download-artifact) to share data between jobs. For example:
>
> Job 1:
>
> ```yaml
>     steps:
>       - uses: actions/checkout@v4
>       - run: mkdir -p path/to/artifact
>       - run: echo hello > path/to/artifact/world.txt
>       - uses: actions/upload-artifact@v4
>         with:
>           name: my-artifact
>           path: path/to/artifact
> ```
> 
> Job 2:
> 
> ```yaml
>     steps:
>       - uses: actions/checkout@v4
>       - uses: actions/download-artifact@v4
>         with:
>           name: my-artifact
>           path: path/to/artifact
>       - run: cat path/to/artifact/world.txt
> ```
>
> (Source: https://stackoverflow.com/a/57877438/1638960)
